### PR TITLE
JAVARS-58: Change import of MongoDriverInformation

### DIFF
--- a/driver/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -18,7 +18,7 @@ package com.mongodb.reactivestreams.client;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.async.client.MongoClientSettings;
-import com.mongodb.client.MongoDriverInformation;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.reactivestreams.client.internal.MongoClientImpl;
 import org.bson.codecs.configuration.CodecRegistry;
 

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
@@ -17,7 +17,7 @@
 package com.mongodb.reactivestreams.client
 
 import com.mongodb.MongoNamespace
-import com.mongodb.client.MongoDriverInformation
+import com.mongodb.MongoDriverInformation
 import com.mongodb.client.model.IndexModel
 import com.mongodb.diagnostics.logging.Loggers
 import org.bson.Document


### PR DESCRIPTION
The Java driver introduced a breaking change in the 3.7 release
by moving MongoDriverInformation to a different package. This
commit responds to that move by changing the import.