### PR TITLE
JAVARS-59 Support transactions

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -360,6 +360,10 @@ axes:
         display_name: "3.6"
         variables:
            VERSION: "3.6"
+      - id: "latest"
+        display_name: "latest"
+        variables:
+           VERSION: "latest"
   - id: "os"
     display_name: "OS"
     values:

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ configure(subprojects.findAll { it.name != 'util' }) {
     evaluationDependsOn(':util')
 
     group = 'org.mongodb'
-    version = '1.8.0-SNAPSHOT'
+    version = '1.9.0-SNAPSHOT'
     sourceCompatibility = JavaVersion.VERSION_1_6
     targetCompatibility = JavaVersion.VERSION_1_6
 

--- a/config/findbugs-exclude.xml
+++ b/config/findbugs-exclude.xml
@@ -14,4 +14,8 @@
         </Not>
     </Match>
 
+    <Match>
+        <Class name="~com.mongodb.reactivestreams.client.ClientSession.*"/>
+        <Bug pattern="NM_SAME_SIMPLE_NAME_AS_INTERFACE"/>
+    </Match>
 </FindBugsFilter>

--- a/driver/build.gradle
+++ b/driver/build.gradle
@@ -20,7 +20,7 @@ description = "A Reactive Streams implementation of the MongoDB Java driver"
 archivesBaseName = 'mongodb-driver-reactivestreams'
 
 dependencies {
-    compile 'org.mongodb:mongodb-driver-async:3.7.0-rc0'
+    compile 'org.mongodb:mongodb-driver-async:3.8.0-SNAPSHOT'
     compile 'org.reactivestreams:reactive-streams:1.0.1'
 
     testCompile 'org.reactivestreams:reactive-streams-tck:1.0.1'

--- a/driver/src/main/com/mongodb/reactivestreams/client/ClientSession.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/ClientSession.java
@@ -23,7 +23,7 @@ import org.reactivestreams.Publisher;
 /**
  * A client session that supports transactions.
  *
- * @since 1.8
+ * @since 1.9
  */
 public interface ClientSession extends com.mongodb.session.ClientSession {
     /**

--- a/driver/src/main/com/mongodb/reactivestreams/client/ClientSession.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/ClientSession.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.reactivestreams.client;
+
+import com.mongodb.TransactionOptions;
+import org.reactivestreams.Publisher;
+
+/**
+ * A client session that supports transactions.
+ *
+ * @since 1.8
+ */
+public interface ClientSession extends com.mongodb.session.ClientSession {
+    /**
+     * Returns true if there is an active transaction on this session, and false otherwise
+     *
+     * @return true if there is an active transaction on this session
+     * @mongodb.server.release 4.0
+     */
+    boolean hasActiveTransaction();
+
+    /**
+     * Gets the transaction options.  Only call this method of the session has an active transaction
+     *
+     * @return the transaction options
+     */
+    TransactionOptions getTransactionOptions();
+
+    /**
+     * For internal use only.
+     *
+     * @return the wrapped session
+     */
+    com.mongodb.async.client.ClientSession getWrapped();
+
+    /**
+     * Start a transaction in the context of this session with default transaction options. A transaction can not be started if there is
+     * already an active transaction on this session.
+     *
+     * @mongodb.server.release 4.0
+     */
+    void startTransaction();
+
+    /**
+     * Start a transaction in the context of this session with the given transaction options. A transaction can not be started if there is
+     * already an active transaction on this session.
+     *
+     * @param transactionOptions the options to apply to the transaction
+     *
+     * @mongodb.server.release 4.0
+     */
+    void startTransaction(TransactionOptions transactionOptions);
+
+    /**
+     * Commit a transaction in the context of this session.  A transaction can only be commmited if one has first been started.
+     *
+     * @return a publisher with a single element indicating when the operation has completed
+     * @mongodb.server.release 4.0
+     */
+    Publisher<Void> commitTransaction();
+
+    /**
+     * Abort a transaction in the context of this session.  A transaction can only be aborted if one has first been started.
+     *
+     * @return a publisher with a single element indicating when the operation has completed
+     * @mongodb.server.release 4.0
+     */
+    Publisher<Void> abortTransaction();
+}

--- a/driver/src/main/com/mongodb/reactivestreams/client/MongoClient.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/MongoClient.java
@@ -19,7 +19,6 @@ package com.mongodb.reactivestreams.client;
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.annotations.Immutable;
 import com.mongodb.async.client.MongoClientSettings;
-import com.mongodb.session.ClientSession;
 import org.bson.Document;
 import org.reactivestreams.Publisher;
 
@@ -117,6 +116,15 @@ public interface MongoClient extends Closeable {
      * @since 1.7
      */
     <TResult> ListDatabasesPublisher<TResult> listDatabases(ClientSession clientSession, Class<TResult> clazz);
+
+    /**
+     * Creates a client session.
+     *
+     * @return a publisher for the client session.
+     * @mongodb.server.release 3.6
+     * @since 1.8
+     */
+    Publisher<ClientSession> startSession();
 
     /**
      * Creates a client session.

--- a/driver/src/main/com/mongodb/reactivestreams/client/MongoClient.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/MongoClient.java
@@ -122,7 +122,7 @@ public interface MongoClient extends Closeable {
      *
      * @return a publisher for the client session.
      * @mongodb.server.release 3.6
-     * @since 1.8
+     * @since 1.9
      */
     Publisher<ClientSession> startSession();
 

--- a/driver/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/MongoCollection.java
@@ -40,7 +40,6 @@ import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.UpdateResult;
-import com.mongodb.session.ClientSession;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/driver/src/main/com/mongodb/reactivestreams/client/MongoDatabase.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/MongoDatabase.java
@@ -22,7 +22,6 @@ import com.mongodb.WriteConcern;
 import com.mongodb.annotations.ThreadSafe;
 import com.mongodb.client.model.CreateCollectionOptions;
 import com.mongodb.client.model.CreateViewOptions;
-import com.mongodb.session.ClientSession;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;

--- a/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/gridfs/GridFSBucket.java
@@ -23,7 +23,7 @@ import com.mongodb.annotations.ThreadSafe;
 import com.mongodb.client.gridfs.model.GridFSDownloadOptions;
 import com.mongodb.client.gridfs.model.GridFSUploadOptions;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.session.ClientSession;
+import com.mongodb.reactivestreams.client.ClientSession;
 import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/ClientSessionImpl.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2016 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.mongodb.reactivestreams.client.internal;
+
+import com.mongodb.Block;
+import com.mongodb.ClientSessionOptions;
+import com.mongodb.TransactionOptions;
+import com.mongodb.async.SingleResultCallback;
+import com.mongodb.reactivestreams.client.ClientSession;
+import com.mongodb.session.ServerSession;
+import org.bson.BsonDocument;
+import org.bson.BsonTimestamp;
+import org.reactivestreams.Publisher;
+
+import static com.mongodb.async.client.Observables.observe;
+
+class ClientSessionImpl implements ClientSession {
+    private final com.mongodb.async.client.ClientSession wrapped;
+    private final Object originator;
+
+    ClientSessionImpl(final com.mongodb.async.client.ClientSession wrapped, final Object originator) {
+        this.wrapped = wrapped;
+        this.originator = originator;
+    }
+
+    @Override
+    public boolean hasActiveTransaction() {
+        return wrapped.hasActiveTransaction();
+    }
+
+    @Override
+    public TransactionOptions getTransactionOptions() {
+        return wrapped.getTransactionOptions();
+    }
+
+    @Override
+    public com.mongodb.async.client.ClientSession getWrapped() {
+        return wrapped;
+    }
+
+    @Override
+    public void startTransaction() {
+        wrapped.startTransaction();
+    }
+
+    @Override
+    public void startTransaction(final TransactionOptions transactionOptions) {
+         wrapped.startTransaction(transactionOptions);
+    }
+
+    @Override
+    public Publisher<Void> commitTransaction() {
+        return new ObservableToPublisher<Void>(observe(new Block<SingleResultCallback<Void>>() {
+            @Override
+            public void apply(final SingleResultCallback<Void> callback) {
+                wrapped.commitTransaction(callback);
+            }
+        }));
+        }
+
+    @Override
+    public Publisher<Void> abortTransaction() {
+        return new ObservableToPublisher<Void>(observe(new Block<SingleResultCallback<Void>>() {
+            @Override
+            public void apply(final SingleResultCallback<Void> callback) {
+                wrapped.abortTransaction(callback);
+            }
+        }));
+    }
+
+    @Override
+    public ClientSessionOptions getOptions() {
+        return wrapped.getOptions();
+    }
+
+    @Override
+    public boolean isCausallyConsistent() {
+        return wrapped.isCausallyConsistent();
+    }
+
+    @Override
+    public Object getOriginator() {
+        return originator;
+    }
+
+    @Override
+    public ServerSession getServerSession() {
+        return wrapped.getServerSession();
+    }
+
+    @Override
+    public BsonTimestamp getOperationTime() {
+        return wrapped.getOperationTime();
+    }
+
+    @Override
+    public void advanceOperationTime(final BsonTimestamp operationTime) {
+        wrapped.advanceOperationTime(operationTime);
+    }
+
+    @Override
+    public void advanceClusterTime(final BsonDocument clusterTime) {
+        wrapped.advanceClusterTime(clusterTime);
+    }
+
+    @Override
+    public BsonDocument getClusterTime() {
+        return wrapped.getClusterTime();
+    }
+
+    @Override
+    public void close() {
+        wrapped.close();
+    }
+}

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSBucketImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/GridFSBucketImpl.java
@@ -30,7 +30,7 @@ import com.mongodb.reactivestreams.client.gridfs.GridFSBucket;
 import com.mongodb.reactivestreams.client.gridfs.GridFSDownloadStream;
 import com.mongodb.reactivestreams.client.gridfs.GridFSFindPublisher;
 import com.mongodb.reactivestreams.client.gridfs.GridFSUploadStream;
-import com.mongodb.session.ClientSession;
+import com.mongodb.reactivestreams.client.ClientSession;
 import org.bson.BsonValue;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
@@ -133,7 +133,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
     @Override
     public GridFSUploadStream openUploadStream(final ClientSession clientSession, final String filename,
                                                final GridFSUploadOptions options) {
-        return new GridFSUploadStreamImpl(wrapped.openUploadStream(clientSession, filename, options));
+        return new GridFSUploadStreamImpl(wrapped.openUploadStream(clientSession.getWrapped(), filename, options));
     }
 
     @Override
@@ -144,7 +144,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
     @Override
     public GridFSUploadStream openUploadStream(final ClientSession clientSession, final BsonValue id, final String filename,
                                                final GridFSUploadOptions options) {
-        return new GridFSUploadStreamImpl(wrapped.openUploadStream(clientSession, id, filename, options));
+        return new GridFSUploadStreamImpl(wrapped.openUploadStream(clientSession.getWrapped(), id, filename, options));
     }
 
     @Override
@@ -189,7 +189,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<ObjectId>(observe(new Block<SingleResultCallback<ObjectId>>() {
             @Override
             public void apply(final SingleResultCallback<ObjectId> callback) {
-                wrapped.uploadFromStream(clientSession, filename, toCallbackAsyncInputStream(source), options, callback);
+                wrapped.uploadFromStream(clientSession.getWrapped(), filename, toCallbackAsyncInputStream(source), options, callback);
             }
         }));
     }
@@ -206,7 +206,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.uploadFromStream(clientSession, id, filename, toCallbackAsyncInputStream(source), options,
+                wrapped.uploadFromStream(clientSession.getWrapped(), id, filename, toCallbackAsyncInputStream(source), options,
                         voidToSuccessCallback(callback));
             }
         }));
@@ -234,12 +234,12 @@ public final class GridFSBucketImpl implements GridFSBucket {
 
     @Override
     public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final ObjectId id) {
-        return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession, id));
+        return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession.getWrapped(), id));
     }
 
     @Override
     public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final BsonValue id) {
-        return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession, id));
+        return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession.getWrapped(), id));
     }
 
     @Override
@@ -250,7 +250,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
     @Override
     public GridFSDownloadStream openDownloadStream(final ClientSession clientSession, final String filename,
                                                    final GridFSDownloadOptions options) {
-        return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession, filename, options));
+        return new GridFSDownloadStreamImpl(wrapped.openDownloadStream(clientSession.getWrapped(), filename, options));
     }
 
     @Override
@@ -295,7 +295,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Long>(observe(new Block<SingleResultCallback<Long>>() {
             @Override
             public void apply(final SingleResultCallback<Long> callback) {
-                wrapped.downloadToStream(clientSession, id, toCallbackAsyncOutputStream(destination), callback);
+                wrapped.downloadToStream(clientSession.getWrapped(), id, toCallbackAsyncOutputStream(destination), callback);
             }
         }));
     }
@@ -305,7 +305,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Long>(observe(new Block<SingleResultCallback<Long>>() {
             @Override
             public void apply(final SingleResultCallback<Long> callback) {
-                wrapped.downloadToStream(clientSession, id, toCallbackAsyncOutputStream(destination), callback);
+                wrapped.downloadToStream(clientSession.getWrapped(), id, toCallbackAsyncOutputStream(destination), callback);
             }
         }));
     }
@@ -321,7 +321,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Long>(observe(new Block<SingleResultCallback<Long>>() {
             @Override
             public void apply(final SingleResultCallback<Long> callback) {
-                wrapped.downloadToStream(clientSession, filename, toCallbackAsyncOutputStream(destination), options, callback);
+                wrapped.downloadToStream(clientSession.getWrapped(), filename, toCallbackAsyncOutputStream(destination), options, callback);
             }
         }));
     }
@@ -338,12 +338,12 @@ public final class GridFSBucketImpl implements GridFSBucket {
 
     @Override
     public GridFSFindPublisher find(final ClientSession clientSession) {
-        return new GridFSFindPublisherImpl(wrapped.find(clientSession));
+        return new GridFSFindPublisherImpl(wrapped.find(clientSession.getWrapped()));
     }
 
     @Override
     public GridFSFindPublisher find(final ClientSession clientSession, final Bson filter) {
-        return new GridFSFindPublisherImpl(wrapped.find(clientSession, filter));
+        return new GridFSFindPublisherImpl(wrapped.find(clientSession.getWrapped(), filter));
     }
 
     @Override
@@ -371,7 +371,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.delete(clientSession, id, voidToSuccessCallback(callback));
+                wrapped.delete(clientSession.getWrapped(), id, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -381,7 +381,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.delete(clientSession, id, voidToSuccessCallback(callback));
+                wrapped.delete(clientSession.getWrapped(), id, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -411,7 +411,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.rename(clientSession, id, newFilename, voidToSuccessCallback(callback));
+                wrapped.rename(clientSession.getWrapped(), id, newFilename, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -421,7 +421,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.rename(clientSession, id, newFilename, voidToSuccessCallback(callback));
+                wrapped.rename(clientSession.getWrapped(), id, newFilename, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -441,7 +441,7 @@ public final class GridFSBucketImpl implements GridFSBucket {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.drop(clientSession, voidToSuccessCallback(callback));
+                wrapped.drop(clientSession.getWrapped(), voidToSuccessCallback(callback));
             }
         }));
     }

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/MongoClientImpl.java
@@ -20,10 +20,10 @@ import com.mongodb.Block;
 import com.mongodb.ClientSessionOptions;
 import com.mongodb.async.SingleResultCallback;
 import com.mongodb.async.client.MongoClientSettings;
+import com.mongodb.reactivestreams.client.ClientSession;
 import com.mongodb.reactivestreams.client.ListDatabasesPublisher;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoDatabase;
-import com.mongodb.session.ClientSession;
 import org.bson.Document;
 import org.reactivestreams.Publisher;
 
@@ -70,7 +70,7 @@ public final class MongoClientImpl implements MongoClient {
 
     @Override
     public Publisher<String> listDatabaseNames(final ClientSession clientSession) {
-        return new ObservableToPublisher<String>(observe(wrapped.listDatabaseNames(clientSession)));
+        return new ObservableToPublisher<String>(observe(wrapped.listDatabaseNames(clientSession.getWrapped())));
     }
 
     @Override
@@ -90,7 +90,12 @@ public final class MongoClientImpl implements MongoClient {
 
     @Override
     public <TResult> ListDatabasesPublisher<TResult> listDatabases(final ClientSession clientSession, final Class<TResult> clazz) {
-        return new ListDatabasesPublisherImpl<TResult>(wrapped.listDatabases(clientSession, clazz));
+        return new ListDatabasesPublisherImpl<TResult>(wrapped.listDatabases(clientSession.getWrapped(), clazz));
+    }
+
+    @Override
+    public Publisher<ClientSession> startSession() {
+        return startSession(ClientSessionOptions.builder().build());
     }
 
     @Override
@@ -98,7 +103,16 @@ public final class MongoClientImpl implements MongoClient {
         return new ObservableToPublisher<ClientSession>(observe(new Block<SingleResultCallback<ClientSession>>() {
             @Override
             public void apply(final SingleResultCallback<ClientSession> clientSessionSingleResultCallback) {
-                wrapped.startSession(options, clientSessionSingleResultCallback);
+                wrapped.startSession(options, new SingleResultCallback<com.mongodb.async.client.ClientSession>() {
+                    @Override
+                    public void onResult(final com.mongodb.async.client.ClientSession result, final Throwable t) {
+                        if (t != null) {
+                            clientSessionSingleResultCallback.onResult(null, t);
+                        } else {
+                            clientSessionSingleResultCallback.onResult(new ClientSessionImpl(result, this), null);
+                        }
+                    }
+                });
             }
         }));
     }

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/MongoCollectionImpl.java
@@ -49,7 +49,7 @@ import com.mongodb.reactivestreams.client.ListIndexesPublisher;
 import com.mongodb.reactivestreams.client.MapReducePublisher;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.session.ClientSession;
+import com.mongodb.reactivestreams.client.ClientSession;
 import org.bson.BsonDocument;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -163,7 +163,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Long>(observe(new Block<SingleResultCallback<Long>>() {
             @Override
             public void apply(final SingleResultCallback<Long> callback) {
-                wrapped.count(clientSession, filter, options, callback);
+                wrapped.count(clientSession.getWrapped(), filter, options, callback);
             }
         }));
     }
@@ -187,7 +187,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     @Override
     public <TResult> DistinctPublisher<TResult> distinct(final ClientSession clientSession, final String fieldName, final Bson filter, 
                                                          final Class<TResult> resultClass) {
-        return new DistinctPublisherImpl<TResult>(wrapped.distinct(clientSession, fieldName, resultClass)).filter(filter);
+        return new DistinctPublisherImpl<TResult>(wrapped.distinct(clientSession.getWrapped(), fieldName, resultClass)).filter(filter);
     }
 
     @Override
@@ -227,7 +227,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
 
     @Override
     public <TResult> FindPublisher<TResult> find(final ClientSession clientSession, final Bson filter, final Class<TResult> clazz) {
-        return new FindPublisherImpl<TResult>(wrapped.find(clientSession, filter, clazz));
+        return new FindPublisherImpl<TResult>(wrapped.find(clientSession.getWrapped(), filter, clazz));
     }
 
     @Override
@@ -248,7 +248,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     @Override
     public <TResult> AggregatePublisher<TResult> aggregate(final ClientSession clientSession, final List<? extends Bson> pipeline,
                                                            final Class<TResult> clazz) {
-        return new AggregatePublisherImpl<TResult>(wrapped.aggregate(clientSession, pipeline, clazz));
+        return new AggregatePublisherImpl<TResult>(wrapped.aggregate(clientSession.getWrapped(), pipeline, clazz));
     }
 
     @Override
@@ -289,7 +289,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     @Override
     public <TResult> ChangeStreamPublisher<TResult> watch(final ClientSession clientSession, final List<? extends Bson> pipeline,
                                                           final Class<TResult> resultClass) {
-        return new ChangeStreamPublisherImpl<TResult>(wrapped.watch(clientSession, pipeline, resultClass));
+        return new ChangeStreamPublisherImpl<TResult>(wrapped.watch(clientSession.getWrapped(), pipeline, resultClass));
     }
 
     @Override
@@ -312,7 +312,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
     @Override
     public <TResult> MapReducePublisher<TResult> mapReduce(final ClientSession clientSession, final String mapFunction,
                                                            final String reduceFunction, final Class<TResult> clazz) {
-        return new MapReducePublisherImpl<TResult>(wrapped.mapReduce(clientSession, mapFunction, reduceFunction, clazz));
+        return new MapReducePublisherImpl<TResult>(wrapped.mapReduce(clientSession.getWrapped(), mapFunction, reduceFunction, clazz));
     }
 
     @Override
@@ -344,7 +344,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<BulkWriteResult>(observe(new Block<SingleResultCallback<BulkWriteResult>>(){
             @Override
             public void apply(final SingleResultCallback<BulkWriteResult> callback) {
-                wrapped.bulkWrite(clientSession, requests, options, callback);
+                wrapped.bulkWrite(clientSession.getWrapped(), requests, options, callback);
             }
         }));
     }
@@ -374,7 +374,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.insertOne(clientSession, document, options, voidToSuccessCallback(callback));
+                wrapped.insertOne(clientSession.getWrapped(), document, options, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -405,7 +405,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.insertMany(clientSession, documents, options, voidToSuccessCallback(callback));
+                wrapped.insertMany(clientSession.getWrapped(), documents, options, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -435,7 +435,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<DeleteResult>(observe(new Block<SingleResultCallback<DeleteResult>>() {
             @Override
             public void apply(final SingleResultCallback<DeleteResult> callback) {
-                wrapped.deleteOne(clientSession, filter, options, callback);
+                wrapped.deleteOne(clientSession.getWrapped(), filter, options, callback);
             }
         }));
     }
@@ -465,7 +465,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<DeleteResult>(observe(new Block<SingleResultCallback<DeleteResult>>() {
             @Override
             public void apply(final SingleResultCallback<DeleteResult> callback) {
-                wrapped.deleteMany(clientSession, filter, options, callback);
+                wrapped.deleteMany(clientSession.getWrapped(), filter, options, callback);
             }
         }));
     }
@@ -508,7 +508,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<UpdateResult>(observe(new Block<SingleResultCallback<UpdateResult>>() {
             @Override
             public void apply(final SingleResultCallback<UpdateResult> callback) {
-                wrapped.replaceOne(clientSession, filter, replacement, options, callback);
+                wrapped.replaceOne(clientSession.getWrapped(), filter, replacement, options, callback);
             }
         }));
     }
@@ -521,7 +521,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
             @SuppressWarnings("deprecation")
             @Override
             public void apply(final SingleResultCallback<UpdateResult> callback) {
-                wrapped.replaceOne(clientSession, filter, replacement, options, callback);
+                wrapped.replaceOne(clientSession.getWrapped(), filter, replacement, options, callback);
             }
         }));
     }
@@ -552,7 +552,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<UpdateResult>(observe(new Block<SingleResultCallback<UpdateResult>>() {
             @Override
             public void apply(final SingleResultCallback<UpdateResult> callback) {
-                wrapped.updateOne(clientSession, filter, update, options, callback);
+                wrapped.updateOne(clientSession.getWrapped(), filter, update, options, callback);
             }
         }));
     }
@@ -583,7 +583,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<UpdateResult>(observe(new Block<SingleResultCallback<UpdateResult>>() {
             @Override
             public void apply(final SingleResultCallback<UpdateResult> callback) {
-                wrapped.updateMany(clientSession, filter, update, options, callback);
+                wrapped.updateMany(clientSession.getWrapped(), filter, update, options, callback);
             }
         }));
     }
@@ -614,7 +614,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<TDocument>(observe(new Block<SingleResultCallback<TDocument>>() {
             @Override
             public void apply(final SingleResultCallback<TDocument> callback) {
-                wrapped.findOneAndDelete(clientSession, filter, options, callback);
+                wrapped.findOneAndDelete(clientSession.getWrapped(), filter, options, callback);
             }
         }));
     }
@@ -645,7 +645,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<TDocument>(observe(new Block<SingleResultCallback<TDocument>>() {
             @Override
             public void apply(final SingleResultCallback<TDocument> callback) {
-                wrapped.findOneAndReplace(clientSession, filter, replacement, options, callback);
+                wrapped.findOneAndReplace(clientSession.getWrapped(), filter, replacement, options, callback);
             }
         }));
     }
@@ -676,7 +676,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<TDocument>(observe(new Block<SingleResultCallback<TDocument>>() {
             @Override
             public void apply(final SingleResultCallback<TDocument> callback) {
-                wrapped.findOneAndUpdate(clientSession, filter, update, options, callback);
+                wrapped.findOneAndUpdate(clientSession.getWrapped(), filter, update, options, callback);
             }
         }));
     }
@@ -696,7 +696,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.drop(clientSession, voidToSuccessCallback(callback));
+                wrapped.drop(clientSession.getWrapped(), voidToSuccessCallback(callback));
             }
         }));
     }
@@ -726,7 +726,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<String>(observe(new Block<SingleResultCallback<String>>() {
             @Override
             public void apply(final SingleResultCallback<String> callback) {
-                wrapped.createIndex(clientSession, key, options, callback);
+                wrapped.createIndex(clientSession.getWrapped(), key, options, callback);
             }
         }));
     }
@@ -757,7 +757,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<String>(observeAndFlatten(new Block<SingleResultCallback<List<String>>>() {
             @Override
             public void apply(final SingleResultCallback<List<String>> callback) {
-                wrapped.createIndexes(clientSession, indexes, createIndexOptions, callback);
+                wrapped.createIndexes(clientSession.getWrapped(), indexes, createIndexOptions, callback);
             }
         }));
     }
@@ -779,7 +779,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
 
     @Override
     public <TResult> ListIndexesPublisher<TResult> listIndexes(final ClientSession clientSession, final Class<TResult> clazz) {
-        return new ListIndexesPublisherImpl<TResult>(wrapped.listIndexes(clientSession, clazz));
+        return new ListIndexesPublisherImpl<TResult>(wrapped.listIndexes(clientSession.getWrapped(), clazz));
     }
 
     @Override
@@ -828,7 +828,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.dropIndex(clientSession, indexName, dropIndexOptions, voidToSuccessCallback(callback));
+                wrapped.dropIndex(clientSession.getWrapped(), indexName, dropIndexOptions, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -838,7 +838,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.dropIndex(clientSession, keys, dropIndexOptions, voidToSuccessCallback(callback));
+                wrapped.dropIndex(clientSession.getWrapped(), keys, dropIndexOptions, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -889,7 +889,7 @@ final class MongoCollectionImpl<TDocument> implements MongoCollection<TDocument>
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.renameCollection(clientSession, newCollectionNamespace, options, voidToSuccessCallback(callback));
+                wrapped.renameCollection(clientSession.getWrapped(), newCollectionNamespace, options, voidToSuccessCallback(callback));
             }
         }));
     }

--- a/driver/src/main/com/mongodb/reactivestreams/client/internal/MongoDatabaseImpl.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/internal/MongoDatabaseImpl.java
@@ -27,7 +27,7 @@ import com.mongodb.reactivestreams.client.ListCollectionsPublisher;
 import com.mongodb.reactivestreams.client.MongoCollection;
 import com.mongodb.reactivestreams.client.MongoDatabase;
 import com.mongodb.reactivestreams.client.Success;
-import com.mongodb.session.ClientSession;
+import com.mongodb.reactivestreams.client.ClientSession;
 import org.bson.Document;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.conversions.Bson;
@@ -153,7 +153,7 @@ public final class MongoDatabaseImpl implements MongoDatabase {
         return new ObservableToPublisher<TResult>(observe(new Block<SingleResultCallback<TResult>>() {
             @Override
             public void apply(final SingleResultCallback<TResult> callback) {
-                wrapped.runCommand(clientSession, command, clazz, callback);
+                wrapped.runCommand(clientSession.getWrapped(), command, clazz, callback);
             }
         }));
     }
@@ -164,7 +164,7 @@ public final class MongoDatabaseImpl implements MongoDatabase {
         return new ObservableToPublisher<TResult>(observe(new Block<SingleResultCallback<TResult>>() {
             @Override
             public void apply(final SingleResultCallback<TResult> callback) {
-                wrapped.runCommand(clientSession, command, readPreference, clazz, callback);
+                wrapped.runCommand(clientSession.getWrapped(), command, readPreference, clazz, callback);
             }
         }));
     }
@@ -184,7 +184,7 @@ public final class MongoDatabaseImpl implements MongoDatabase {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.drop(clientSession, voidToSuccessCallback(callback));
+                wrapped.drop(clientSession.getWrapped(), voidToSuccessCallback(callback));
             }
         }));
     }
@@ -196,7 +196,7 @@ public final class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public Publisher<String> listCollectionNames(final ClientSession clientSession) {
-        return new ObservableToPublisher<String>(observe(wrapped.listCollectionNames(clientSession)));
+        return new ObservableToPublisher<String>(observe(wrapped.listCollectionNames(clientSession.getWrapped())));
     }
 
     @Override
@@ -216,7 +216,7 @@ public final class MongoDatabaseImpl implements MongoDatabase {
 
     @Override
     public <C> ListCollectionsPublisher<C> listCollections(final ClientSession clientSession, final Class<C> clazz) {
-        return new ListCollectionsPublisherImpl<C>(wrapped.listCollections(clientSession, clazz));
+        return new ListCollectionsPublisherImpl<C>(wrapped.listCollections(clientSession.getWrapped(), clazz));
     }
 
     @Override
@@ -245,7 +245,7 @@ public final class MongoDatabaseImpl implements MongoDatabase {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.createCollection(clientSession, collectionName, options, voidToSuccessCallback(callback));
+                wrapped.createCollection(clientSession.getWrapped(), collectionName, options, voidToSuccessCallback(callback));
             }
         }));
     }
@@ -278,7 +278,8 @@ public final class MongoDatabaseImpl implements MongoDatabase {
         return new ObservableToPublisher<Success>(observe(new Block<SingleResultCallback<Success>>() {
             @Override
             public void apply(final SingleResultCallback<Success> callback) {
-                wrapped.createView(clientSession, viewName, viewOn, pipeline, createViewOptions, voidToSuccessCallback(callback));
+                wrapped.createView(clientSession.getWrapped(), viewName, viewOn, pipeline, createViewOptions,
+                        voidToSuccessCallback(callback));
             }
         }));
     }

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
@@ -21,6 +21,7 @@ import com.mongodb.MongoDriverInformation
 import com.mongodb.client.model.IndexModel
 import com.mongodb.diagnostics.logging.Loggers
 import org.bson.Document
+import spock.lang.IgnoreIf
 
 import static Fixture.getMongoClient
 import static com.mongodb.reactivestreams.client.Fixture.getConnectionString
@@ -38,7 +39,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
         def updatedDocument = new Document('_id', 1).append('a', 1)
 
         when:
-        run('clean up old database', mongoClient.getDatabase(databaseName).&drop) == Success.SUCCESS
+        run('clean up old database', mongoClient.getDatabase(databaseName).&drop)
         def names = run('get database names', mongoClient.&listDatabaseNames)
 
         then: 'Get Database Names'
@@ -143,6 +144,36 @@ class SmokeTestSpecification extends FunctionalSpecification {
         !run('the collection name is no longer in the collectionNames list', database.&listCollectionNames).contains(collectionName)
     }
 
+    // IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet() })
+    def 'should commit a transaction'() {
+        given:
+        run('create collection', database.&createCollection, collection.namespace.collectionName)
+
+        when:
+        ClientSession session = run('start a session', getMongoClient().&startSession)[0] as ClientSession
+        session.startTransaction()
+        run('insert a document', collection.&insertOne, session, new Document('_id', 1))
+        run('commit a transaction', session.&commitTransaction)
+
+        then:
+        run('The count is one', collection.&count)[0] == 1
+    }
+
+    // IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet() })
+    def 'should abort a transaction'() {
+        given:
+        run('create collection', database.&createCollection, collection.namespace.collectionName)
+
+        when:
+        ClientSession session = run('start a session', getMongoClient().&startSession)[0] as ClientSession
+        session.startTransaction()
+        run('insert a document', collection.&insertOne, session, new Document('_id', 1))
+        run('abort a transaction', session.&abortTransaction)
+
+        then:
+        run('The count is zero', collection.&count)[0] == 0
+    }
+
     def 'should not leak exceptions when a client is closed'() {
         given:
         def mongoClient = MongoClients.create(getConnectionString())
@@ -199,7 +230,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
     }
 
     def run(String log, operation, ... args) {
-        LOGGER.debug(log);
+        LOGGER.debug(log)
         def subscriber = new Fixture.ObservableSubscriber()
         operation.call(args).subscribe(subscriber)
         subscriber.get(30, SECONDS)

--- a/driver/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
+++ b/driver/src/test/functional/com/mongodb/reactivestreams/client/SmokeTestSpecification.groovy
@@ -25,6 +25,8 @@ import spock.lang.IgnoreIf
 
 import static Fixture.getMongoClient
 import static com.mongodb.reactivestreams.client.Fixture.getConnectionString
+import static com.mongodb.reactivestreams.client.Fixture.isReplicaSet
+import static com.mongodb.reactivestreams.client.Fixture.serverVersionAtLeast
 import static java.util.concurrent.TimeUnit.SECONDS
 
 class SmokeTestSpecification extends FunctionalSpecification {
@@ -144,7 +146,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
         !run('the collection name is no longer in the collectionNames list', database.&listCollectionNames).contains(collectionName)
     }
 
-    // IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet() })
+    @IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet()) })
     def 'should commit a transaction'() {
         given:
         run('create collection', database.&createCollection, collection.namespace.collectionName)
@@ -159,7 +161,7 @@ class SmokeTestSpecification extends FunctionalSpecification {
         run('The count is one', collection.&count)[0] == 1
     }
 
-    // IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet() })
+    @IgnoreIf({ !(serverVersionAtLeast(3, 7) && isReplicaSet()) })
     def 'should abort a transaction'() {
         given:
         run('create collection', database.&createCollection, collection.namespace.collectionName)

--- a/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionImplSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/ClientSessionImplSpecification.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.reactivestreams.client.internal
+
+import com.mongodb.ClientSessionOptions
+import com.mongodb.ReadConcern
+import com.mongodb.TransactionOptions
+import com.mongodb.async.client.ClientSession
+import com.mongodb.reactivestreams.client.MongoClient
+import com.mongodb.session.ServerSession
+import org.bson.BsonBoolean
+import org.bson.BsonDocument
+import org.bson.BsonTimestamp
+import org.reactivestreams.Subscriber
+import spock.lang.Specification
+
+class ClientSessionImplSpecification extends Specification {
+    def 'should forward methods to wrapped'() {
+        given:
+        def originator = Stub(MongoClient)
+        def wrapped = Mock(ClientSession)
+        def session = new ClientSessionImpl(wrapped, originator)
+        def expectedTransactionOptions = TransactionOptions.builder().readConcern(ReadConcern.MAJORITY).build()
+        def expectedSessionOptions = ClientSessionOptions.builder().causallyConsistent(false).build()
+        def expectedClusterTime = new BsonDocument('x', BsonBoolean.TRUE)
+        def expectedOperationTime = new BsonTimestamp(42, 1)
+        def expectedServerSession = Stub(ServerSession)
+        def subscriber = Stub(Subscriber) {
+            onSubscribe(_) >> { args -> args[0].request(1) }
+        }
+
+        expect:
+        session.getOriginator() == originator
+        session.getWrapped() == wrapped
+
+        when:
+        def causallyConsistent = session.isCausallyConsistent()
+
+        then:
+        causallyConsistent
+        1 * wrapped.isCausallyConsistent() >> true
+
+        when:
+        def transactionOptions = session.getTransactionOptions()
+
+        then:
+        transactionOptions == expectedTransactionOptions
+        1 * wrapped.getTransactionOptions() >> expectedTransactionOptions
+
+        when:
+        def hasActiveTransaction = session.hasActiveTransaction()
+
+        then:
+        hasActiveTransaction
+        1 * wrapped.hasActiveTransaction() >> true
+
+        when:
+        def sessionOptions = session.getOptions()
+
+        then:
+        sessionOptions == expectedSessionOptions
+        1 * wrapped.getOptions() >> expectedSessionOptions
+
+        when:
+        def clusterTime = session.getClusterTime()
+
+        then:
+        clusterTime == expectedClusterTime
+        1 * wrapped.getClusterTime() >> expectedClusterTime
+
+        when:
+        def operationTime = session.getOperationTime()
+
+        then:
+        operationTime == expectedOperationTime
+        1 * wrapped.getOperationTime() >> expectedOperationTime
+
+        when:
+        def serverSession = session.getServerSession()
+
+        then:
+        serverSession == expectedServerSession
+        1 * wrapped.getServerSession() >> expectedServerSession
+
+        when:
+        session.advanceClusterTime(expectedClusterTime)
+
+        then:
+        1 * wrapped.advanceClusterTime(expectedClusterTime)
+
+        when:
+        session.advanceOperationTime(expectedOperationTime)
+
+        then:
+        1 * wrapped.advanceOperationTime(expectedOperationTime)
+
+        when:
+        session.startTransaction()
+
+        then:
+        1 * wrapped.startTransaction()
+
+        when:
+        session.startTransaction(expectedTransactionOptions)
+
+        then:
+        1 * wrapped.startTransaction(expectedTransactionOptions)
+
+        when:
+        session.commitTransaction().subscribe(subscriber)
+
+        then:
+        1 * wrapped.commitTransaction(_)
+
+        when:
+        session.abortTransaction().subscribe(subscriber)
+
+        then:
+        1 * wrapped.abortTransaction(_)
+
+        when:
+        session.close()
+
+        then:
+        1 * wrapped.close()
+    }
+}

--- a/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/GridFSBucketImplSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/GridFSBucketImplSpecification.groovy
@@ -28,7 +28,8 @@ import com.mongodb.client.gridfs.model.GridFSUploadOptions
 import com.mongodb.reactivestreams.client.gridfs.AsyncInputStream
 import com.mongodb.reactivestreams.client.gridfs.AsyncOutputStream
 import com.mongodb.reactivestreams.client.gridfs.GridFSBucket
-import com.mongodb.session.ClientSession
+import com.mongodb.reactivestreams.client.ClientSession
+import com.mongodb.async.client.ClientSession as WrappedClientSession
 import org.bson.BsonObjectId
 import org.bson.Document
 import org.reactivestreams.Subscriber
@@ -40,7 +41,10 @@ class GridFSBucketImplSpecification extends Specification {
         onSubscribe(_) >> { args -> args[0].request(100) }
     }
 
-    def clientSession = Stub(ClientSession)
+    def wrappedClientSession = Stub(WrappedClientSession)
+    def clientSession = Stub(ClientSession) {
+        getWrapped() >> wrappedClientSession
+    }
 
     def 'should have the same methods as the wrapped GridFSBucket'() {
         given:
@@ -159,25 +163,25 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.openUploadStream(clientSession, filename)
 
         then:
-        1 * wrapped.openUploadStream(clientSession, filename, _) >> uploadStream
+        1 * wrapped.openUploadStream(wrappedClientSession, filename, _) >> uploadStream
 
         when:
         bucket.openUploadStream(clientSession, filename, options)
 
         then:
-        1 * wrapped.openUploadStream(clientSession, filename, options) >> uploadStream
+        1 * wrapped.openUploadStream(wrappedClientSession, filename, options) >> uploadStream
 
         when:
         bucket.openUploadStream(clientSession, fileId, filename)
 
         then:
-        1 * wrapped.openUploadStream(clientSession, fileId, filename, _) >> uploadStream
+        1 * wrapped.openUploadStream(wrappedClientSession, fileId, filename, _) >> uploadStream
 
         when:
         bucket.openUploadStream(clientSession, fileId, filename, options)
 
         then:
-        1 * wrapped.openUploadStream(clientSession, fileId, filename, options) >> uploadStream
+        1 * wrapped.openUploadStream(wrappedClientSession, fileId, filename, options) >> uploadStream
     }
 
     def 'should call the wrapped uploadFromStream'() {
@@ -230,25 +234,25 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.uploadFromStream(clientSession, filename, source).subscribe(subscriber)
 
         then:
-        1 * wrapped.uploadFromStream(clientSession, filename, _, _, _)
+        1 * wrapped.uploadFromStream(wrappedClientSession, filename, _, _, _)
 
         when:
         bucket.uploadFromStream(clientSession, filename, source, options).subscribe(subscriber)
 
         then:
-        1 * wrapped.uploadFromStream(clientSession, filename, _, options, _)
+        1 * wrapped.uploadFromStream(wrappedClientSession, filename, _, options, _)
 
         when:
         bucket.uploadFromStream(clientSession, fileId, filename, source).subscribe(subscriber)
 
         then:
-        1 * wrapped.uploadFromStream(clientSession, fileId, filename, _, _, _)
+        1 * wrapped.uploadFromStream(wrappedClientSession, fileId, filename, _, _, _)
 
         when:
         bucket.uploadFromStream(clientSession, fileId, filename, source, options).subscribe(subscriber)
 
         then:
-        1 * wrapped.uploadFromStream(clientSession, fileId, filename, _, options, _)
+        1 * wrapped.uploadFromStream(wrappedClientSession, fileId, filename, _, options, _)
     }
 
     def 'should call the wrapped openDownloadStream'() {
@@ -288,25 +292,25 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.openDownloadStream(clientSession, fileId)
 
         then:
-        1 * wrapped.openDownloadStream(clientSession, fileId) >> downloadStream
+        1 * wrapped.openDownloadStream(wrappedClientSession, fileId) >> downloadStream
 
         when:
         bucket.openDownloadStream(clientSession, fileId.getValue())
 
         then:
-        1 * wrapped.openDownloadStream(clientSession, fileId.getValue()) >> downloadStream
+        1 * wrapped.openDownloadStream(wrappedClientSession, fileId.getValue()) >> downloadStream
 
         when:
         bucket.openDownloadStream(clientSession, filename)
 
         then:
-        1 * wrapped.openDownloadStream(clientSession, filename, _) >> downloadStream
+        1 * wrapped.openDownloadStream(wrappedClientSession, filename, _) >> downloadStream
 
         when:
         bucket.openDownloadStream(clientSession, filename, options)
 
         then:
-        1 * wrapped.openDownloadStream(clientSession, filename, options) >> downloadStream
+        1 * wrapped.openDownloadStream(wrappedClientSession, filename, options) >> downloadStream
     }
 
     def 'should call the wrapped downloadToStream'() {
@@ -359,25 +363,25 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.downloadToStream(clientSession, fileId, destination).subscribe(subscriber)
 
         then:
-        1 * wrapped.downloadToStream(clientSession, fileId, _, _)
+        1 * wrapped.downloadToStream(wrappedClientSession, fileId, _, _)
 
         when:
         bucket.downloadToStream(clientSession, fileId.getValue(), destination).subscribe(subscriber)
 
         then:
-        1 * wrapped.downloadToStream(clientSession, fileId.getValue(), _, _)
+        1 * wrapped.downloadToStream(wrappedClientSession, fileId.getValue(), _, _)
 
         when:
         bucket.downloadToStream(clientSession, filename, destination).subscribe(subscriber)
 
         then:
-        1 * wrapped.downloadToStream(clientSession, filename, _, _, _)
+        1 * wrapped.downloadToStream(wrappedClientSession, filename, _, _, _)
 
         when:
         bucket.downloadToStream(clientSession, filename, destination, options).subscribe(subscriber)
 
         then:
-        1 * wrapped.downloadToStream(clientSession, filename, _, options, _)
+        1 * wrapped.downloadToStream(wrappedClientSession, filename, _, options, _)
     }
 
     def 'should call the underlying find method'() {
@@ -403,13 +407,13 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.find(clientSession)
 
         then:
-        1 * wrapped.find(clientSession) >> findIterable
+        1 * wrapped.find(wrappedClientSession) >> findIterable
 
         when:
         bucket.find(clientSession, filter)
 
         then:
-        1 * wrapped.find(clientSession, filter) >> findIterable
+        1 * wrapped.find(wrappedClientSession, filter) >> findIterable
     }
 
     def 'should call the underlying delete method'() {
@@ -446,13 +450,13 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.delete(clientSession, fileId).subscribe(subscriber)
 
         then:
-        1 * wrapped.delete(clientSession, fileId, _)
+        1 * wrapped.delete(wrappedClientSession, fileId, _)
 
         when:
         bucket.delete(clientSession, fileId.getValue()).subscribe(subscriber)
 
         then:
-        1 * wrapped.delete(clientSession, fileId.getValue(), _)
+        1 * wrapped.delete(wrappedClientSession, fileId.getValue(), _)
     }
 
     def 'should call the underlying rename method'() {
@@ -490,13 +494,13 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.rename(clientSession, fileId, newFilename).subscribe(subscriber)
 
         then:
-        1 * wrapped.rename(clientSession, fileId, newFilename, _)
+        1 * wrapped.rename(wrappedClientSession, fileId, newFilename, _)
 
         when:
         bucket.rename(clientSession, fileId.getValue(), newFilename).subscribe(subscriber)
 
         then:
-        1 * wrapped.rename(clientSession, fileId.getValue(), newFilename, _)
+        1 * wrapped.rename(wrappedClientSession, fileId.getValue(), newFilename, _)
     }
 
     def 'should call the underlying drop method'() {
@@ -527,7 +531,7 @@ class GridFSBucketImplSpecification extends Specification {
         bucket.drop(clientSession).subscribe(subscriber)
 
         then:
-        1 * wrapped.drop(clientSession, _)
+        1 * wrapped.drop(wrappedClientSession, _)
     }
 
 }

--- a/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoDatabaseImplSpecification.groovy
+++ b/driver/src/test/unit/com/mongodb/reactivestreams/client/internal/MongoDatabaseImplSpecification.groovy
@@ -24,7 +24,8 @@ import com.mongodb.async.client.MongoDatabase as WrappedMongoDatabase
 import com.mongodb.client.model.CreateCollectionOptions
 import com.mongodb.client.model.CreateViewOptions
 import com.mongodb.reactivestreams.client.MongoDatabase
-import com.mongodb.session.ClientSession
+import com.mongodb.reactivestreams.client.ClientSession
+import com.mongodb.async.client.ClientSession as WrappedClientSession
 import org.bson.BsonDocument
 import org.bson.Document
 import org.bson.codecs.configuration.CodecRegistry
@@ -36,7 +37,10 @@ import static spock.util.matcher.HamcrestSupport.expect
 
 class MongoDatabaseImplSpecification extends Specification {
 
-    def clientSession = Stub(ClientSession)
+    def wrappedClientSession = Stub(WrappedClientSession)
+    def clientSession = Stub(ClientSession) {
+        getWrapped() >> wrappedClientSession
+    }
 
     def 'should have the same methods as the wrapped MongoDatabase'() {
         given:
@@ -224,13 +228,13 @@ class MongoDatabaseImplSpecification extends Specification {
         mongoDatabase.runCommand(clientSession, new Document()).subscribe(subscriber)
 
         then:
-        1 * wrapped.runCommand(clientSession, new Document(), Document, _)
+        1 * wrapped.runCommand(wrappedClientSession, new Document(), Document, _)
 
         when:
         mongoDatabase.runCommand(clientSession, new BsonDocument(), BsonDocument).subscribe(subscriber)
 
         then:
-        1 * wrapped.runCommand(clientSession, new BsonDocument(), BsonDocument, _)
+        1 * wrapped.runCommand(wrappedClientSession, new BsonDocument(), BsonDocument, _)
     }
 
     def 'should call the underlying runCommand for read operations'() {
@@ -264,13 +268,13 @@ class MongoDatabaseImplSpecification extends Specification {
         mongoDatabase.runCommand(clientSession, new Document(), readPreference).subscribe(subscriber)
 
         then:
-        1 * wrapped.runCommand(clientSession, new Document(), readPreference, Document, _)
+        1 * wrapped.runCommand(wrappedClientSession, new Document(), readPreference, Document, _)
 
         when:
         mongoDatabase.runCommand(clientSession, new BsonDocument(), readPreference, BsonDocument).subscribe(subscriber)
 
         then:
-        1 * wrapped.runCommand(clientSession, new BsonDocument(), readPreference, BsonDocument, _)
+        1 * wrapped.runCommand(wrappedClientSession, new BsonDocument(), readPreference, BsonDocument, _)
     }
 
     def 'should call the underlying drop'() {
@@ -298,7 +302,7 @@ class MongoDatabaseImplSpecification extends Specification {
         mongoDatabase.drop(clientSession).subscribe(subscriber)
 
         then:
-        1 * wrapped.drop(clientSession, _)
+        1 * wrapped.drop(wrappedClientSession, _)
     }
     def 'should call the underlying listCollectionNames'() {
         given:
@@ -315,7 +319,7 @@ class MongoDatabaseImplSpecification extends Specification {
         mongoDatabase.listCollectionNames(clientSession)
 
         then:
-        1 * wrapped.listCollectionNames(clientSession)
+        1 * wrapped.listCollectionNames(wrappedClientSession)
 
     }
     def 'should call the underlying listCollections'() {
@@ -342,14 +346,14 @@ class MongoDatabaseImplSpecification extends Specification {
         publisher = mongoDatabase.listCollections(clientSession)
 
         then:
-        1 * wrapped.listCollections(clientSession, Document) >> wrappedResult
+        1 * wrapped.listCollections(wrappedClientSession, Document) >> wrappedResult
         expect publisher, isTheSameAs(new ListCollectionsPublisherImpl(wrappedResult))
 
         when:
         publisher = mongoDatabase.listCollections(clientSession, BsonDocument)
 
         then:
-        1 * wrapped.listCollections(clientSession, BsonDocument) >> wrappedResult
+        1 * wrapped.listCollections(wrappedClientSession, BsonDocument) >> wrappedResult
         expect publisher, isTheSameAs(new ListCollectionsPublisherImpl(wrappedResult))
     }
 
@@ -384,13 +388,13 @@ class MongoDatabaseImplSpecification extends Specification {
         mongoDatabase.createCollection(clientSession, 'collectionName').subscribe(subscriber)
 
         then:
-        1 * wrapped.createCollection(clientSession, 'collectionName', _, _)
+        1 * wrapped.createCollection(wrappedClientSession, 'collectionName', _, _)
 
         when:
         mongoDatabase.createCollection(clientSession, 'collectionName', createCollectionOptions).subscribe(subscriber)
 
         then:
-        1 * wrapped.createCollection(clientSession, 'collectionName', createCollectionOptions, _)
+        1 * wrapped.createCollection(wrappedClientSession, 'collectionName', createCollectionOptions, _)
     }
 
     def 'should call the underlying createView'() {
@@ -427,12 +431,12 @@ class MongoDatabaseImplSpecification extends Specification {
         mongoDatabase.createView(clientSession, viewName, viewOn, pipeline).subscribe(subscriber)
 
         then:
-        1 * wrapped.createView(clientSession, viewName, viewOn, pipeline, _,  _)
+        1 * wrapped.createView(wrappedClientSession, viewName, viewOn, pipeline, _,  _)
 
         when:
         mongoDatabase.createView(clientSession, viewName, viewOn, pipeline, createViewOptions).subscribe(subscriber)
 
         then:
-        1 * wrapped.createView(clientSession, viewName, viewOn, pipeline, createViewOptions, _)
+        1 * wrapped.createView(wrappedClientSession, viewName, viewOn, pipeline, createViewOptions, _)
     }
 }


### PR DESCRIPTION
A few notes on the design and implementation:

* It introduces a small but significant breaking change to the existing
  API for any applications that already depend on session support
  (introduced in the 1.7 release to support causal consistency): the type
  of ClientSession changes from com.mongodb.session.ClientSession to
  com.mongodb.reactivestreams.client.ClientSession.  This is both source
  and binary incompatible.
* It adds an overload to MongoClient.startSession that takes no
  ClientSessionOptions, as we expect it to be a common pattern to not
  need any options.