### PR TITLE
Deprecate MongoClients.create(com.mongodb.async.client.MongoClient)

### DIFF
--- a/driver/src/main/com/mongodb/reactivestreams/client/MongoClients.java
+++ b/driver/src/main/com/mongodb/reactivestreams/client/MongoClients.java
@@ -134,7 +134,9 @@ public final class MongoClients {
      * @param asyncMongoClient the async MongoClient
      * @return the client
      * @since 1.4
+     * @deprecated Deprecated because {@link com.mongodb.async.client.MongoClient} is deprecated.
      */
+    @Deprecated
     public static MongoClient create(final com.mongodb.async.client.MongoClient asyncMongoClient) {
         return new MongoClientImpl(asyncMongoClient);
     }


### PR DESCRIPTION
Deprecated since com.mongodb.async.client.MongoClient is now deprecated.

JAVARS-119